### PR TITLE
Added “flatten para” capability to RenderPara

### DIFF
--- a/Convert/DocConverter.cs
+++ b/Convert/DocConverter.cs
@@ -1,4 +1,4 @@
-﻿﻿//
+//
 // DocConverter.cs: Routines to turn ECMA XML into an HTML string and this subset of HTML back into ECMA XML
 //
 // Author:
@@ -741,7 +741,7 @@ class EcmaToXml {
 				} else if (flattenNestedParas && xel.Name == "para")
 				{
 					//Only allow 1 level of nesting, since use-case is <para> as node under, e.g., <example>
-					RenderPara(xel.Nodes(), false);
+					sb.Append(RenderPara(xel.Nodes(), false));
 				} else {
 					Console.WriteLine ("File: {0}, Node: {1}", currentFile, node);
 					throw new UnsupportedElementException ("Unsupported element in RenderPara: " + xel.Name);


### PR DESCRIPTION
Fixes https://github.com/xamarin/DocWriter/issues/25

Added flag to `DocConverter.RenderPara` that allows nested <para>. Defaults to `false`, but called with `true` from `RenderExample`, which allows <para> below <example>.